### PR TITLE
Update VerbFilter.php

### DIFF
--- a/framework/filters/VerbFilter.php
+++ b/framework/filters/VerbFilter.php
@@ -54,8 +54,8 @@ class VerbFilter extends Behavior
      * allowed methods (e.g. GET, HEAD, PUT) as the value.
      * If an action is not listed all request methods are considered allowed.
      *
-     * You can use '*' to stand for all actions. When an action is explicitly
-     * specified, it takes precedence over the specification given by '*'.
+     * You can use '\*' to stand for all actions. When an action is explicitly
+     * specified, it takes precedence over the specification given by '\*'.
      *
      * For example,
      *


### PR DESCRIPTION
Delimited asterisks in documentation that were being interpreted as Markdown emphasis.